### PR TITLE
Fix missing Beatmap data and add SliderEndtime

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "include/osu!parser/Parser/Dependencies/pocketlzma"]
 	path = include/osu!parser/Parser/Dependencies/pocketlzma
-	url = https://github.com/SSBMTonberry/pocketlzma
+	url = https://github.com/SSBMTonberry/pocketlzma.git

--- a/Tests.cpp
+++ b/Tests.cpp
@@ -2,9 +2,9 @@
 
 int main()
 {
-    const std::string GamePath = std::string(std::getenv("localappdata")) + "\\osu!\\";
-    const std::string SongsPath = std::string(std::getenv("localappdata")) + "\\osu!\\Songs\\";
-    const std::string ReplaysPath = std::string(std::getenv("localappdata")) + "\\osu!\\Replays\\";
+    const std::string GamePath = ""; // Your osu! path here
+    const std::string SongsPath = GamePath + "\\Songs\\";
+    const std::string ReplaysPath = GamePath + "\\Replays\\";
 
     const Parser::Database ParsedDatabase(GamePath + "osu!.db");
 
@@ -14,6 +14,7 @@ int main()
 
     const Parser::Beatmap ParsedBeatmap(SongsPath + Beatmap.FolderName + "\\" + Beatmap.BeatmapPath);
 
+	std::cout << "Overall Difficulty - " << ParsedBeatmap.Difficulty.OverallDifficulty << "\n";
     std::cout << "Audio Filename - " << ParsedBeatmap.General.AudioFilename << "\n";
     std::cout << "Artist - " << ParsedBeatmap.Metadata.Artist << "\n";
     std::cout << "Approach Rate - " << ParsedBeatmap.Difficulty.ApproachRate << "\n";

--- a/include/osu!parser/Parser/Beatmap.hpp
+++ b/include/osu!parser/Parser/Beatmap.hpp
@@ -55,26 +55,38 @@ namespace Parser
             {
                 HitObject Object;
                 const std::vector<std::string> SplitObject = Utilities::Split(ObjectString, ',');
-                Object.X = std::stoi(SplitObject[0]);
-                Object.Y = std::stoi(SplitObject[1]);
-                Object.Time = std::stoi(SplitObject[2]);
-                Object.Type = HitObjectType(std::stoi(SplitObject[3]));
-                Object.HitSound = HitSoundType(std::stoi(SplitObject[4]));
-                switch(Object.Type)
-                {
-                    case HitObjectType::SLIDER:
-                    {
-                        std::vector<std::string> SplitCurvePoints = Utilities::Split(SplitObject[5], '|');
-                        SplitCurvePoints.erase(SplitCurvePoints.begin());
-                        Object.CurveType = SplitObject[5][0];
-                        for(const std::string& PointString : SplitCurvePoints)
-                        {
-                            const std::vector<std::string> SplitPoint = Utilities::Split(PointString, ':');
-                            Object.CurvePoints.push_back({ std::stoi(SplitPoint[0]), std::stoi(SplitPoint[1]) });   
-                        }
-                        break;
-                    }
+                Object.x = std::stoi(SplitObject[0]);
+                Object.y = std::stoi(SplitObject[1]);
+                Object.time = std::stoi(SplitObject[2]);
+                Object.type = HitObjectType(std::stoi(SplitObject[3]));
+				Object.hitSound = Hitsound(std::stoi(SplitObject[4]));
+
+                // Parsing objectParams
+                /// as Slider
+                if (Object.type == HitObjectType::SLIDER) {
+                    Object.sliderParams->curve.import(SplitObject[5]);
+                    Object.sliderParams->slides = std::stoi(SplitObject[6]);
+                    Object.sliderParams->length = std::stod(SplitObject[7]);
+                    Object.sliderParams->edgeHitsounds.import(SplitObject[8], SplitObject[9]);
                 }
+                else Object.sliderParams = std::nullopt;
+                /// as Spinner
+				if (Object.type == HitObjectType::SPINNER) {
+					Object.spinnerParams->endTime = std::stoi(SplitObject[5]);
+				}
+				else Object.spinnerParams = std::nullopt;
+
+				//Parsing hitSample
+				if (Object.type == HitObjectType::SLIDER && SplitObject.size() >= 11) {
+					Object.hitSample = HitObject::HitSample(SplitObject[10]);
+				}
+                else if (Object.type == HitObjectType::SPINNER && SplitObject.size() >= 7) {
+					Object.hitSample = HitObject::HitSample(SplitObject[6]);
+                }
+				else if (Object.type == HitObjectType::HIT_CIRCLE && SplitObject.size() >= 6) {
+					Object.hitSample = HitObject::HitSample(SplitObject[5]);
+				}
+
                 this->HitObjects.push_back(Object);
             }
 

--- a/include/osu!parser/Parser/Beatmap.hpp
+++ b/include/osu!parser/Parser/Beatmap.hpp
@@ -72,20 +72,28 @@ namespace Parser
                 else Object.sliderParams = std::nullopt;
                 /// as Spinner
 				if (Object.type.Spinner) {
-					Object.spinnerParams->endTime = std::stoi(SplitObject[5]);
+					Object.endTime = std::stoi(SplitObject[5]);
 				}
-				else Object.spinnerParams = std::nullopt;
 
-				// Parsing hitSample
-				if (Object.type.Slider && SplitObject.size() >= 11) {
-					Object.hitSample = HitObject::HitSample(SplitObject[10]);
-				}
-                else if (Object.type.Spinner && SplitObject.size() >= 7) {
-					Object.hitSample = HitObject::HitSample(SplitObject[6]);
+                // while HoldNote is special case
+                if (Object.type.HoldNote) {
+                    auto list = Utilities::Split(SplitObject[5], ':', true);
+                    Object.endTime = std::stoi(list.front());
+                    Object.hitSample = HitObject::HitSample(list.back());
                 }
-				else if (Object.type.HitCircle && SplitObject.size() >= 6) {
-					Object.hitSample = HitObject::HitSample(SplitObject[5]);
-				}
+
+				// Parsing hitSample for other
+                if (!Object.type.HoldNote) {
+                    if (Object.type.Slider && SplitObject.size() >= 11) {
+                        Object.hitSample = HitObject::HitSample(SplitObject[10]);
+                    }
+                    else if (Object.type.Spinner && SplitObject.size() >= 7) {
+                        Object.hitSample = HitObject::HitSample(SplitObject[6]);
+                    }
+                    else if (Object.type.HitCircle && SplitObject.size() >= 6) {
+                        Object.hitSample = HitObject::HitSample(SplitObject[5]);
+                    }
+                }
 
                 this->HitObjects.push_back(Object);
             }

--- a/include/osu!parser/Parser/Beatmap.hpp
+++ b/include/osu!parser/Parser/Beatmap.hpp
@@ -16,7 +16,7 @@
 namespace Parser
 {
     static constexpr int MINIMUM_LINE_CHARACTERS = 3;
-    static constexpr std::string NA = "N/A";
+    static const std::string NA = "N/A";
 
     class Beatmap
     {

--- a/include/osu!parser/Parser/Beatmap.hpp
+++ b/include/osu!parser/Parser/Beatmap.hpp
@@ -13,10 +13,11 @@
 #include "Structures/Beatmap/Sections/DifficultySection.hpp"
 #include "Structures/Beatmap/Sections/EditorSection.hpp"
 
-static constexpr int MINIMUM_LINE_CHARACTER = 3;
-
 namespace Parser
 {
+    static constexpr int MINIMUM_LINE_CHARACTERS = 3;
+    static constexpr std::string NA = "N/A";
+
     class Beatmap
     {
     public:
@@ -28,7 +29,7 @@ namespace Parser
                 return;
             }
 
-            std::string CurrentLine = "N/A";
+            std::string CurrentLine = NA;
             std::getline(m_CurrentStream, CurrentLine);
             while(std::getline(m_CurrentStream, CurrentLine))
             {
@@ -40,7 +41,7 @@ namespace Parser
                     continue;
                 }
 				// In >=C++11, std::string can save UTF-8 string (non-ascii char will be saved as 2 bytes, but in that one byte it looks weird)
-                if (CurrentLine.size() < MINIMUM_LINE_CHARACTER) continue;
+                if (CurrentLine.size() < MINIMUM_LINE_CHARACTERS) continue;
 
                 this->m_Sections[CurrentSection].push_back(CurrentLine);
             }

--- a/include/osu!parser/Parser/Beatmap.hpp
+++ b/include/osu!parser/Parser/Beatmap.hpp
@@ -16,7 +16,6 @@
 namespace Parser
 {
     static constexpr int MINIMUM_LINE_CHARACTERS = 3;
-    static const std::string NA = "N/A";
 
     class Beatmap
     {
@@ -29,7 +28,7 @@ namespace Parser
                 return;
             }
 
-            std::string CurrentLine = NA;
+            std::string CurrentLine;
             std::getline(m_CurrentStream, CurrentLine);
             while(std::getline(m_CurrentStream, CurrentLine))
             {

--- a/include/osu!parser/Parser/Beatmap.hpp
+++ b/include/osu!parser/Parser/Beatmap.hpp
@@ -13,6 +13,8 @@
 #include "Structures/Beatmap/Sections/DifficultySection.hpp"
 #include "Structures/Beatmap/Sections/EditorSection.hpp"
 
+static constexpr int MINIMUM_LINE_CHARACTER = 3;
+
 namespace Parser
 {
     class Beatmap
@@ -31,15 +33,15 @@ namespace Parser
             while(std::getline(m_CurrentStream, CurrentLine))
             {
                 CurrentLine = Utilities::Trim(CurrentLine);
-                static std::string CurrentSection = "General";
-                if(CurrentLine.find('[') != std::string::npos && CurrentLine.find(']') != std::string::npos)
+                static std::string CurrentSection;
+				if (!CurrentLine.empty() && CurrentLine.front() == '[' && CurrentLine.back() == ']')
                 {
                     CurrentSection = Utilities::Split(Utilities::Split(CurrentLine, '[')[1], ']')[0];
-                }
-                if(CurrentLine.size() < 3 || CurrentLine.find("Unicode") != std::string::npos || CurrentLine.find(CurrentSection) != std::string::npos)
-                {
                     continue;
-                }   
+                }
+				// In >=C++11, std::string can save UTF-8 string (non-ascii char will be saved as 2 bytes, but in that one byte it looks weird)
+                if (CurrentLine.size() < MINIMUM_LINE_CHARACTER) continue;
+
                 this->m_Sections[CurrentSection].push_back(CurrentLine);
             }
 

--- a/include/osu!parser/Parser/Beatmap.hpp
+++ b/include/osu!parser/Parser/Beatmap.hpp
@@ -58,32 +58,33 @@ namespace Parser
                 Object.x = std::stoi(SplitObject[0]);
                 Object.y = std::stoi(SplitObject[1]);
                 Object.time = std::stoi(SplitObject[2]);
-                Object.type = HitObjectType(std::stoi(SplitObject[3]));
+                Object.type = HitObjectType(std::stoi(SplitObject[3]), (this->HitObjects.empty()), 
+                    (this->HitObjects.empty()) ? 1 : (this->HitObjects.back().type.comboColor));
 				Object.hitSound = Hitsound(std::stoi(SplitObject[4]));
 
                 // Parsing objectParams
                 /// as Slider
-                if (Object.type == HitObjectType::SLIDER) {
+                if (Object.type.Slider) {
                     Object.sliderParams->curve.import(SplitObject[5]);
                     Object.sliderParams->slides = std::stoi(SplitObject[6]);
                     Object.sliderParams->length = std::stod(SplitObject[7]);
-                    Object.sliderParams->edgeHitsounds.import(SplitObject[8], SplitObject[9]);
+                    if (SplitObject.size()>=10) Object.sliderParams->edgeHitsounds.import(SplitObject[8], SplitObject[9]);
                 }
                 else Object.sliderParams = std::nullopt;
                 /// as Spinner
-				if (Object.type == HitObjectType::SPINNER) {
+				if (Object.type.Spinner) {
 					Object.spinnerParams->endTime = std::stoi(SplitObject[5]);
 				}
 				else Object.spinnerParams = std::nullopt;
 
-				//Parsing hitSample
-				if (Object.type == HitObjectType::SLIDER && SplitObject.size() >= 11) {
+				// Parsing hitSample
+				if (Object.type.Slider && SplitObject.size() >= 11) {
 					Object.hitSample = HitObject::HitSample(SplitObject[10]);
 				}
-                else if (Object.type == HitObjectType::SPINNER && SplitObject.size() >= 7) {
+                else if (Object.type.Spinner && SplitObject.size() >= 7) {
 					Object.hitSample = HitObject::HitSample(SplitObject[6]);
                 }
-				else if (Object.type == HitObjectType::HIT_CIRCLE && SplitObject.size() >= 6) {
+				else if (Object.type.HitCircle && SplitObject.size() >= 6) {
 					Object.hitSample = HitObject::HitSample(SplitObject[5]);
 				}
 

--- a/include/osu!parser/Parser/Beatmap.hpp
+++ b/include/osu!parser/Parser/Beatmap.hpp
@@ -32,7 +32,7 @@ namespace Parser
             {
                 CurrentLine = Utilities::Trim(CurrentLine);
                 static std::string CurrentSection = "General";
-                if(CurrentLine.find("[") != std::string::npos && CurrentLine.find("]") != std::string::npos)
+                if(CurrentLine.find('[') != std::string::npos && CurrentLine.find(']') != std::string::npos)
                 {
                     CurrentSection = Utilities::Split(Utilities::Split(CurrentLine, '[')[1], ']')[0];
                 }

--- a/include/osu!parser/Parser/Beatmap.hpp
+++ b/include/osu!parser/Parser/Beatmap.hpp
@@ -4,8 +4,7 @@
 #include <fstream>
 #include <iostream>
 #include <map>
-#include <sstream>
-#include <format>
+#include <algorithm>
 #include "Structures/Beatmap/TimingPoint.hpp"
 #include "Structures/Beatmap/HitObject.hpp"
 #include "Structures/Beatmap/Sections/GeneralSection.hpp"
@@ -15,121 +14,160 @@
 
 namespace Parser
 {
-    static constexpr int MINIMUM_LINE_CHARACTERS = 3;
+	static constexpr int MINIMUM_LINE_CHARACTERS = 3;
 
-    class Beatmap
-    {
-    public:
-        Beatmap(const std::string& BeatmapPath) : m_CurrentStream(BeatmapPath)
-        {
-            this->Reset();
-            if(!m_CurrentStream.good())
-            {
-                return;
-            }
+	class Beatmap
+	{
+	public:
+		Beatmap(const std::string& BeatmapPath) : m_CurrentStream(BeatmapPath)
+		{
+			this->Reset();
+			if (!m_CurrentStream.good())
+			{
+				return;
+			}
 
-            std::string CurrentLine;
-            std::getline(m_CurrentStream, CurrentLine);
-            while(std::getline(m_CurrentStream, CurrentLine))
-            {
-                CurrentLine = Utilities::Trim(CurrentLine);
-                static std::string CurrentSection;
+			std::string CurrentLine;
+			std::getline(m_CurrentStream, CurrentLine);
+			while (std::getline(m_CurrentStream, CurrentLine))
+			{
+				CurrentLine = Utilities::Trim(CurrentLine);
+				static std::string CurrentSection;
 				if (!CurrentLine.empty() && CurrentLine.front() == '[' && CurrentLine.back() == ']')
-                {
-                    CurrentSection = Utilities::Split(Utilities::Split(CurrentLine, '[')[1], ']')[0];
-                    continue;
-                }
+				{
+					CurrentSection = Utilities::Split(Utilities::Split(CurrentLine, '[')[1], ']')[0];
+					continue;
+				}
 				// In >=C++11, std::string can save UTF-8 string (non-ascii char will be saved as 2 bytes, but in that one byte it looks weird)
-                if (CurrentLine.size() < MINIMUM_LINE_CHARACTERS) continue;
+				if (CurrentLine.size() < MINIMUM_LINE_CHARACTERS) continue;
 
-                this->m_Sections[CurrentSection].push_back(CurrentLine);
-            }
+				this->m_Sections[CurrentSection].push_back(CurrentLine);
+			}
 
-            this->General.Parse(this->m_Sections["General"]);
-            this->Metadata.Parse(this->m_Sections["Metadata"]);
-            this->Editor.Parse(this->m_Sections["Editor"]);
-            this->Difficulty.Parse(this->m_Sections["Difficulty"]);
-            
-            for(const std::string& ObjectString : this->m_Sections["HitObjects"])
-            {
-                HitObject Object;
-                const std::vector<std::string> SplitObject = Utilities::Split(ObjectString, ',');
-                Object.x = std::stoi(SplitObject[0]);
-                Object.y = std::stoi(SplitObject[1]);
-                Object.time = std::stoi(SplitObject[2]);
-                Object.type = HitObjectType(std::stoi(SplitObject[3]), (this->HitObjects.empty()), 
-                    (this->HitObjects.empty()) ? 1 : (this->HitObjects.back().type.comboColor));
+			this->General.Parse(this->m_Sections["General"]);
+			this->Metadata.Parse(this->m_Sections["Metadata"]);
+			this->Editor.Parse(this->m_Sections["Editor"]);
+			this->Difficulty.Parse(this->m_Sections["Difficulty"]);
+
+			for (const std::string& PointString : this->m_Sections["TimingPoints"])
+			{
+				TimingPoint Point;
+				const std::vector<std::string> SplitPoint = Utilities::Split(PointString, ',');
+				Point.Time = std::stoi(SplitPoint[0]);
+				Point.BeatLength = std::stof(SplitPoint[1]);
+				Point.Meter = std::stoi(SplitPoint[2]);
+				Point.SampleSet = std::stoi(SplitPoint[3]);
+				Point.SampleIndex = std::stoi(SplitPoint[4]);
+				Point.Volume = std::stoi(SplitPoint[5]);
+				Point.Uninherited = (std::stoi(SplitPoint[6]) == 1);
+				Point.Effects = std::stoi(SplitPoint[7]);
+				
+				if (Point.Uninherited) this->UninheritedTimingPoints.push_back(Point);
+				else this->InheritedTimingPoints.push_back(Point);
+			}
+			std::sort(this->UninheritedTimingPoints.begin(), this->UninheritedTimingPoints.end());
+			std::sort(this->InheritedTimingPoints.begin(), this->InheritedTimingPoints.end());
+
+			for (const std::string& ObjectString : this->m_Sections["HitObjects"])
+			{
+				HitObject Object;
+				const std::vector<std::string> SplitObject = Utilities::Split(ObjectString, ',');
+				Object.x = std::stoi(SplitObject[0]);
+				Object.y = std::stoi(SplitObject[1]);
+				Object.time = std::stoi(SplitObject[2]);
+				Object.type = HitObjectType(std::stoi(SplitObject[3]), (this->HitObjects.empty()),
+					(this->HitObjects.empty()) ? 1 : (this->HitObjects.back().type.comboColor));
 				Object.hitSound = Hitsound(std::stoi(SplitObject[4]));
 
-                // Parsing objectParams
-                /// as Slider
-                if (Object.type.Slider) {
-                    Object.sliderParams->curve.import(SplitObject[5]);
-                    Object.sliderParams->slides = std::stoi(SplitObject[6]);
-                    Object.sliderParams->length = std::stod(SplitObject[7]);
-                    if (SplitObject.size()>=10) Object.sliderParams->edgeHitsounds.import(SplitObject[8], SplitObject[9]);
-                }
-                else Object.sliderParams = std::nullopt;
-                /// as Spinner
+				// Parsing objectParams
+				/// as Slider
+				if (Object.type.Slider) {
+					Object.sliderParams->curve.import(SplitObject[5]);
+					Object.sliderParams->slides = std::stoi(SplitObject[6]);
+					Object.sliderParams->length = std::stod(SplitObject[7]);
+					if (SplitObject.size() >= 10) Object.sliderParams->edgeHitsounds.import(SplitObject[8], SplitObject[9]);
+				}
+				else Object.sliderParams = std::nullopt;
+				/// as Spinner
 				if (Object.type.Spinner) {
 					Object.endTime = std::stoi(SplitObject[5]);
 				}
-
-                // while HoldNote is special case
-                if (Object.type.HoldNote) {
-                    auto list = Utilities::Split(SplitObject[5], ':', true);
-                    Object.endTime = std::stoi(list.front());
-                    Object.hitSample = HitObject::HitSample(list.back());
-                }
+				// while HoldNote is special case
+				if (Object.type.HoldNote) {
+					auto list = Utilities::Split(SplitObject[5], ':', true);
+					Object.endTime = std::stoi(list.front());
+					Object.hitSample = HitObject::HitSample(list.back());
+				}
 
 				// Parsing hitSample for other
-                if (!Object.type.HoldNote) {
-                    if (Object.type.Slider && SplitObject.size() >= 11) {
-                        Object.hitSample = HitObject::HitSample(SplitObject[10]);
-                    }
-                    else if (Object.type.Spinner && SplitObject.size() >= 7) {
-                        Object.hitSample = HitObject::HitSample(SplitObject[6]);
-                    }
-                    else if (Object.type.HitCircle && SplitObject.size() >= 6) {
-                        Object.hitSample = HitObject::HitSample(SplitObject[5]);
-                    }
-                }
+				if (!Object.type.HoldNote) {
+					if (Object.type.Slider && SplitObject.size() >= 11) {
+						Object.hitSample = HitObject::HitSample(SplitObject[10]);
+					}
+					else if (Object.type.Spinner && SplitObject.size() >= 7) {
+						Object.hitSample = HitObject::HitSample(SplitObject[6]);
+					}
+					else if (Object.type.HitCircle && SplitObject.size() >= 6) {
+						Object.hitSample = HitObject::HitSample(SplitObject[5]);
+					}
+				}
 
-                this->HitObjects.push_back(Object);
-            }
+				// Calculate endTime
+				if (!Object.type.HoldNote)
+					if (Object.type.HitCircle) { Object.endTime = Object.time; }
+					else if (Object.type.Slider) {
+						if (!this->Difficulty.SliderMultiplier.empty() && !this->UninheritedTimingPoints.empty())
+						{
+							TimingPoint currentTimeAsTimepoint;
+							currentTimeAsTimepoint.Time = Object.time;
 
-            for(const std::string& PointString : this->m_Sections["TimingPoints"])
-            {
-                TimingPoint Point;
-                const std::vector<std::string> SplitPoint = Utilities::Split(PointString, ',');
-                Point.Time = std::stoi(SplitPoint[0]);
-                Point.BeatLength = std::stof(SplitPoint[1]);
-                Point.Meter = std::stoi(SplitPoint[2]);
-                Point.SampleSet = std::stoi(SplitPoint[3]);
-                Point.SampleIndex = std::stoi(SplitPoint[4]);
-                Point.Volume = std::stoi(SplitPoint[5]);
-                Point.Uninherited = std::stoi(SplitPoint[6]);
-                Point.Effects = std::stoi(SplitPoint[7]);
-                this->TimingPoints.push_back(Point);
-            }
-        }
-    private:
-        void Reset()
-        {
-            this->Version = 14;
-            this->TimingPoints.clear();
-            this->HitObjects.clear();
-        }
-    public:
-        GeneralSection General;
-        MetadataSection Metadata;
-        EditorSection Editor;
-        DifficultySection Difficulty;
-        std::int32_t Version = 14;
-        std::vector<TimingPoint> TimingPoints = {};
-        std::vector<HitObject> HitObjects = {};
-    private:
-        std::ifstream m_CurrentStream;
-        std::map<std::string, std::vector<std::string>> m_Sections = {};
-    };
+							// Get SliderMultiplier
+							double_t SliderMultiplier = std::stod(this->Difficulty.SliderMultiplier);
+
+							// Get BeatLength
+							auto CurrentUninheritedTimingPoint =
+								std::lower_bound(this->UninheritedTimingPoints.begin(), this->UninheritedTimingPoints.end(), currentTimeAsTimepoint);
+							if (CurrentUninheritedTimingPoint == this->UninheritedTimingPoints.end())
+								CurrentUninheritedTimingPoint = this->UninheritedTimingPoints.begin();
+							double_t BeatLength = CurrentUninheritedTimingPoint->BeatLength;
+
+							// Get SV
+							double_t SV;
+							auto CurrentInheritedTimingPoint =
+								std::lower_bound(this->InheritedTimingPoints.begin(), this->InheritedTimingPoints.end(), currentTimeAsTimepoint);
+							if (CurrentInheritedTimingPoint == this->InheritedTimingPoints.end()) SV = 1;
+							else SV = SliderMultiplier * (100.0 / std::abs(CurrentInheritedTimingPoint->BeatLength));
+
+							Object.endTime = 
+								Object.time + Object.sliderParams->length / (SliderMultiplier * 100 * SV) * BeatLength * Object.sliderParams->slides;
+						}
+						else Object.endTime = Object.time;
+					}
+
+				this->HitObjects.push_back(Object);
+			}
+			std::sort(this->HitObjects.begin(), this->HitObjects.end(),
+				[](const HitObject& A, const HitObject& B) { return A.time < B.time; });
+		}
+	private:
+		void Reset()
+		{
+			this->Version = 14;
+			this->UninheritedTimingPoints.clear();
+			this->InheritedTimingPoints.clear();
+			this->HitObjects.clear();
+		}
+	public:
+		GeneralSection General;
+		MetadataSection Metadata;
+		EditorSection Editor;
+		DifficultySection Difficulty;
+		std::int32_t Version = 14;
+		std::vector<TimingPoint> UninheritedTimingPoints = {};
+		std::vector<TimingPoint> InheritedTimingPoints = {};
+		std::vector<HitObject> HitObjects = {};
+	private:
+		std::ifstream m_CurrentStream;
+		std::map<std::string, std::vector<std::string>> m_Sections = {};
+	};
 }

--- a/include/osu!parser/Parser/Structures/Beatmap/HitObject.hpp
+++ b/include/osu!parser/Parser/Structures/Beatmap/HitObject.hpp
@@ -2,7 +2,7 @@
 #include <osu!parser/Parser/Utilities.hpp>
 #include <optional>
 
-static enum class TypeBitmap : std::int32_t
+static enum class HitObjectTypeBitmap : std::int32_t
 {
 	HIT_CIRCLE = 1 << 0,
 	SLIDER = 1 << 1,
@@ -35,7 +35,6 @@ namespace Parser
 		SOFT = 2,
 		DRUM = 3
 	};
-
 	struct Hitsound
 	{
 		bool whistle = false;
@@ -72,15 +71,15 @@ namespace Parser
 
 		void import(const std::int32_t value, const bool isFirstNote = false, const std::int32_t oldComboColor = 1)
 		{
-			HitCircle = isBitEnable(value, std::int32_t(TypeBitmap::HIT_CIRCLE));
-			Slider = isBitEnable(value, std::int32_t(TypeBitmap::SLIDER));
-			Spinner = isBitEnable(value, std::int32_t(TypeBitmap::SPINNER));
-			HoldNote = isBitEnable(value, std::int32_t(TypeBitmap::HOLD_NOTE));
-			isNewCombo = isBitEnable(value, std::int32_t(TypeBitmap::NEW_COMBO));
+			HitCircle = isBitEnable(value, std::int32_t(HitObjectTypeBitmap::HIT_CIRCLE));
+			Slider = isBitEnable(value, std::int32_t(HitObjectTypeBitmap::SLIDER));
+			Spinner = isBitEnable(value, std::int32_t(HitObjectTypeBitmap::SPINNER));
+			HoldNote = isBitEnable(value, std::int32_t(HitObjectTypeBitmap::HOLD_NOTE));
+			isNewCombo = isBitEnable(value, std::int32_t(HitObjectTypeBitmap::NEW_COMBO));
 
-			bool bit4 = isBitEnable(value, std::int32_t(TypeBitmap::COLOR_JUMP0));
-			bool bit5 = isBitEnable(value, std::int32_t(TypeBitmap::COLOR_JUMP1));
-			bool bit6 = isBitEnable(value, std::int32_t(TypeBitmap::COLOR_JUMP2));
+			bool bit4 = isBitEnable(value, std::int32_t(HitObjectTypeBitmap::COLOR_JUMP0));
+			bool bit5 = isBitEnable(value, std::int32_t(HitObjectTypeBitmap::COLOR_JUMP1));
+			bool bit6 = isBitEnable(value, std::int32_t(HitObjectTypeBitmap::COLOR_JUMP2));
 			std::int32_t colorJump = (bit6 << 2) | (bit5 << 1) | bit4;
 
 			if (isFirstNote) comboColor = colorJump + 1;
@@ -171,8 +170,8 @@ namespace Parser
 				EdgeHitsounds(const std::string edgeSounds_str, const std::string edgeSets_str) { import(edgeSounds_str, edgeSets_str); }
 			};
 
-			unsigned int slides = 1; // aka Repeats
-			unsigned int length = 0; // aka PixelLength
+			std::int32_t slides = 1; // aka Repeats
+			std::double_t length = 0; // aka PixelLength
 			SliderCurve curve;
 			EdgeHitsounds edgeHitsounds; // <edgeSounds + edgeSets> list
 		};
@@ -239,15 +238,11 @@ namespace Parser
 		};
 
 		std::int32_t x = 0, y = 0;
-		unsigned int time = 0;
+		std::int32_t time = 0;
 		HitObjectType type;
 		Hitsound hitSound;
 		std::optional<SliderParams> sliderParams = SliderParams();
-		std::optional<unsigned int> endTime = std::nullopt;
-		//? Future Idea: Calculate Slider's endTime
-		// Slider endTime can be calculated through slider length, but
-		// to do it we need to know SliderMultiplier, SV and beatLength, which is not provided in HitObject
-		// https://osu.ppy.sh/wiki/en/Client/File_formats/osu_%28file_format%29#holds-(osu!mania-only):~:text=length%20/%20(SliderMultiplier%20*%20100%20*%20SV)%20*%20beatLength
+		std::int32_t endTime; // Bonus
 		HitSample hitSample;
 	};
 }

--- a/include/osu!parser/Parser/Structures/Beatmap/HitObject.hpp
+++ b/include/osu!parser/Parser/Structures/Beatmap/HitObject.hpp
@@ -1,31 +1,221 @@
 #pragma once
+#include <osu!parser/Parser/Utilities.hpp>
+#include <optional>
+#include <variant>
 
 namespace Parser
 {
-    enum class HitObjectType : std::int32_t
-    {
-        HIT_CIRCLE = 1 << 0,
-        SLIDER = 1 << 1,
-        SPINNER = 1 << 3,
-    };
+	enum class TypeBitmap : std::int32_t
+	{
+		HIT_CIRCLE = 1 << 0,
+		SLIDER = 1 << 1,
+		SPINNER = 1 << 3,
+	};
+	enum class HitsoundBitmap : std::uint8_t
+	{
+		// https://osu.ppy.sh/wiki/en/Client/File_formats/osu_%28file_format%29#sliders:~:text=mania%20hold%20note.-,Hitsounds,-The%20hitSound%20bit
 
-    enum class HitSoundType : std::int32_t
-    {
-        NORMAL = 0,
-        WHISTLE = 1,
-        FINISH = 2,
-        CLAP = 3
-    };
+		NORMAL = 1 << 0,
+		// below is additional
+		WHISTLE = 1 << 1,
+		FINISH = 1 << 2,
+		CLAP = 1 << 3
+	};
+	enum class SampleSetType : std::int32_t
+	{
+		NO_CUSTOM = 0,
+		NORMAL = 1,
+		SOFT = 2,
+		DRUM = 3
+	};
 
-    struct HitObject
-    {
-        std::int32_t X = 0, Y = 0;
-        std::int32_t Time = 0;
-        HitObjectType Type = HitObjectType::HIT_CIRCLE;
-        HitSoundType HitSound = HitSoundType::NORMAL;        
-        char CurveType = 'B';
-        std::vector<std::pair<std::int32_t, std::int32_t>> CurvePoints = {};
-        std::int32_t Repeats = 0;
-        std::double_t PixelLength = 0.0;
-    };
+	struct Hitsound
+	{
+		bool whistle = false;
+		bool finish = false;
+		bool clap = false;
+
+		void import(const std::int32_t hitsound)
+		{
+			whistle = (hitsound & std::int32_t(HitsoundBitmap::WHISTLE)) != 0;
+			finish = (hitsound & std::int32_t(HitsoundBitmap::FINISH)) != 0;
+			clap = (hitsound & std::int32_t(HitsoundBitmap::CLAP)) != 0;
+		}
+		std::int32_t to_int() const
+		{
+			std::int32_t hitsound = std::int32_t(HitsoundBitmap::NORMAL);
+			if (whistle) hitsound |= std::int32_t(HitsoundBitmap::WHISTLE);
+			if (finish) hitsound |= std::int32_t(HitsoundBitmap::FINISH);
+			if (clap) hitsound |= std::int32_t(HitsoundBitmap::CLAP);
+			return hitsound;
+		}
+
+		Hitsound() = default;
+		Hitsound(const std::int32_t hitsound_int) { import(hitsound_int); }
+	};
+
+	struct HitObjectType
+	{
+		
+	};
+
+	struct HitObject
+	{
+		// https://osu.ppy.sh/wiki/en/Client/File_formats/osu_%28file_format%29#sliders:~:text=additional%20objectParams.-,Sliders,-Slider%20syntax%3A
+		struct SliderParams
+		{
+			struct SliderCurve
+			{
+				enum class CurveType : char
+				{
+					BEZIER = 'B', // bézier
+					CATMULL = 'C', // centripetal catmull-rom
+					LINEAR = 'L',
+					PERFECT = 'P'
+				};
+
+				CurveType curveType;
+				std::vector<std::pair<std::int32_t, std::int32_t>> curvePoints = {};
+
+				void import(const std::string& Curve_str)
+				{
+					std::vector<std::string> Curve = Utilities::Split(Curve_str, '|');
+
+					// curveType
+					curveType = CurveType(Curve.front().front());
+					Curve.erase(Curve.begin());
+
+					// curvePoints (now Curve is became curvePoints - aka curvePoint list)
+					for (const std::string& CurvePoint : Curve)
+					{
+						const std::vector<std::string> SplitPoint = Utilities::Split(CurvePoint, ':');
+						curvePoints.emplace_back(std::stoi(SplitPoint[0]), std::stoi(SplitPoint[1]));
+					}
+				}
+
+				SliderCurve() = default;
+				SliderCurve(const std::string& Curve_str) { import(Curve_str); }
+			};
+			struct EdgeHitsound
+			{
+				struct SampleSet
+				{
+					SampleSetType normalSet = SampleSetType::NO_CUSTOM;
+					SampleSetType additionSet = SampleSetType::NO_CUSTOM;
+
+					void import(const std::string& edgeSet_str)
+					{
+						if (edgeSet_str.empty()) return; //not written
+						auto list = Utilities::Split(edgeSet_str, ':');
+						normalSet = SampleSetType(std::stoi(list[0]));
+						additionSet = SampleSetType(std::stoi(list[1]));
+					}
+
+					SampleSet() = default;
+					SampleSet(const std::string& edgeSet_str) { import(edgeSet_str); }
+				};
+
+				Hitsound sound; // edgeSounds 
+				SampleSet sample; // edgeSets
+			};
+			struct EdgeHitsounds: std::vector<EdgeHitsound>
+			{
+				void import(const std::string edgeSounds_str, const std::string edgeSets_str)
+				{
+					auto edgeSounds = Utilities::Split(edgeSounds_str, '|');
+					auto edgeSets = Utilities::Split(edgeSets_str, '|');
+
+					for (std::int32_t i=0; i < edgeSounds.size(); i++)
+					{
+						EdgeHitsound edgeHitsound;
+						edgeHitsound.sound.import(std::stoi(edgeSounds[i]));
+						edgeHitsound.sample.import(edgeSets[i]);
+
+						this->push_back(edgeHitsound);
+					}
+				}
+
+				EdgeHitsounds() = default;
+				EdgeHitsounds(const std::string edgeSounds_str, const std::string edgeSets_str) { import(edgeSounds_str, edgeSets_str); }
+			};
+
+			std::int32_t slides = 1; // aka Repeats
+			std::double_t length = 0; // aka PixelLength
+			SliderCurve curve;
+			EdgeHitsounds edgeHitsounds; // <edgeSounds + edgeSets> list
+		};
+		struct SpinnerParams
+		{
+			std::int32_t endTime = 0;
+		};
+		struct HitSample
+		{
+			// https://osu.ppy.sh/wiki/en/Client/File_formats/osu_%28file_format%29#hitsounds:~:text=enabled%20by%20default.-,Custom%20hit%20samples,-Usage%20of%20hitSample
+
+			SampleSetType normalSet = SampleSetType::NO_CUSTOM;
+			SampleSetType additionSet = SampleSetType::NO_CUSTOM;
+			std::int32_t index = 0;
+			std::int32_t volume = 0;
+			std::string filename;
+
+			HitSample() = default;
+			HitSample(const std::string hitsample_str)
+			{
+				if (hitsample_str.empty()) return; //not written
+				auto list = Utilities::Split(hitsample_str, ':');
+				normalSet = SampleSetType(std::stoi(list[0]));
+				additionSet = SampleSetType(std::stoi(list[1]));
+				index = std::stoi(list[2]);
+				volume = std::stoi(list[3]);
+				if (list.size() > 4) { filename = list[4]; }
+			}
+
+			std::string getHitsoundTypeFilename(const HitsoundBitmap hitsoundType)
+			{
+				if (!filename.empty())
+				{
+					// Only provide Normal hitsound
+					if (hitsoundType == HitsoundBitmap::NORMAL) return filename;
+					return ""; 
+				}
+
+				//sampleSet
+				SampleSetType sampleSet = (hitsoundType == HitsoundBitmap::NORMAL) ? normalSet : additionSet;
+				std::string sampleSetStr;
+				switch (sampleSet)
+				{
+				case SampleSetType::NORMAL: sampleSetStr = "normal"; break;
+				case SampleSetType::SOFT: sampleSetStr = "soft"; break;
+				case SampleSetType::DRUM: sampleSetStr = "drum"; break;
+				default: return ""; // No custom sampleSet, use skin hitsound instand
+				}
+
+				// hitSound
+				std::string hitsoundTypeStr;
+				switch (hitsoundType)
+				{
+				case HitsoundBitmap::WHISTLE: hitsoundTypeStr = "whistle"; break;
+				case HitsoundBitmap::FINISH: hitsoundTypeStr = "finish"; break;
+				case HitsoundBitmap::CLAP: hitsoundTypeStr = "clap"; break;
+				default: hitsoundTypeStr = "normal"; break;
+				}
+
+				std::string filename;
+				filename.append(sampleSetStr);
+				filename.append("-hit");
+				filename.append(hitsoundTypeStr);
+				if (index != 0 && index != 1) filename.append(std::to_string(index));
+				filename.append(".wav");
+				return filename;
+			}
+		};
+
+		std::int32_t x = 0, y = 0;
+		std::int32_t time = 0;
+		TypeBitmap type = TypeBitmap::HIT_CIRCLE;
+		Hitsound hitSound;
+		std::optional<SliderParams> sliderParams = SliderParams();
+		std::optional<SpinnerParams> spinnerParams = SpinnerParams();
+		HitSample hitSample;
+	};
 }

--- a/include/osu!parser/Parser/Structures/Beatmap/HitObject.hpp
+++ b/include/osu!parser/Parser/Structures/Beatmap/HitObject.hpp
@@ -176,10 +176,6 @@ namespace Parser
 			SliderCurve curve;
 			EdgeHitsounds edgeHitsounds; // <edgeSounds + edgeSets> list
 		};
-		struct SpinnerParams
-		{
-			unsigned int endTime = 0;
-		};
 		struct HitSample
 		{
 			// https://osu.ppy.sh/wiki/en/Client/File_formats/osu_%28file_format%29#hitsounds:~:text=enabled%20by%20default.-,Custom%20hit%20samples,-Usage%20of%20hitSample
@@ -247,7 +243,11 @@ namespace Parser
 		HitObjectType type;
 		Hitsound hitSound;
 		std::optional<SliderParams> sliderParams = SliderParams();
-		std::optional<SpinnerParams> spinnerParams = SpinnerParams();
+		std::optional<unsigned int> endTime = std::nullopt;
+		//? Future Idea: Calculate Slider's endTime
+		// Slider endTime can be calculated through slider length, but
+		// to do it we need to know SliderMultiplier, SV and beatLength, which is not provided in HitObject
+		// https://osu.ppy.sh/wiki/en/Client/File_formats/osu_%28file_format%29#holds-(osu!mania-only):~:text=length%20/%20(SliderMultiplier%20*%20100%20*%20SV)%20*%20beatLength
 		HitSample hitSample;
 	};
 }

--- a/include/osu!parser/Parser/Structures/Beatmap/Sections/MetadataSection.hpp
+++ b/include/osu!parser/Parser/Structures/Beatmap/Sections/MetadataSection.hpp
@@ -22,6 +22,7 @@ namespace Parser
             this->Source = this->GetAttribute("Source");
             this->BeatmapID = this->GetAttribute("BeatmapID");
             this->BeatmapSetID = this->GetAttribute("BeatmapSetID");
+			this->Tags = Utilities::Split(this->GetAttribute("Tags"), ' ');
         }
     public:
         std::string Title;
@@ -33,5 +34,6 @@ namespace Parser
         std::string Source;
         std::string BeatmapID;
         std::string BeatmapSetID;
+        std::vector<std::string> Tags;
     };
 }

--- a/include/osu!parser/Parser/Structures/Beatmap/Sections/Section.hpp
+++ b/include/osu!parser/Parser/Structures/Beatmap/Sections/Section.hpp
@@ -19,11 +19,11 @@ namespace Parser
         {
             for(const std::string& Line : Lines)
             {
-                if(Line.find(":") == std::string::npos)
+                if(Line.find(':') == std::string::npos)
                 {
                     continue;
                 }
-                std::vector<std::string> SplitLine = Utilities::Split(Line, ':');
+                std::vector<std::string> SplitLine = Utilities::Split(Line, ':', true);
                 if(SplitLine.size() > 1)
                 {
                     this->InsertAttribute(SplitLine[0], Utilities::Trim(SplitLine[1]));

--- a/include/osu!parser/Parser/Structures/Beatmap/Sections/Section.hpp
+++ b/include/osu!parser/Parser/Structures/Beatmap/Sections/Section.hpp
@@ -12,7 +12,9 @@ namespace Parser
     protected:
         std::string GetAttribute(const std::string& Key)
         {
-            return this->m_SectionMap[Key].size() ? this->m_SectionMap[Key] : "N/A";
+            return this->m_SectionMap[Key].size() ? this->m_SectionMap[Key] : "";
+			// if not found, should return empty string because may be "N/A" is known as a valid value
+            // you can check by using std::string::empty()
         }
 
         void LoadAttributes(const std::vector<std::string>& Lines)

--- a/include/osu!parser/Parser/Structures/Beatmap/TimingPoint.hpp
+++ b/include/osu!parser/Parser/Structures/Beatmap/TimingPoint.hpp
@@ -5,12 +5,19 @@ namespace Parser
     struct TimingPoint
     {
         std::int32_t Time;
-        std::float_t BeatLength;
+        std::double_t BeatLength;
         std::int32_t Meter;
         std::int32_t SampleSet;
         std::int32_t SampleIndex;
         std::int32_t Volume;
-        std::int32_t Uninherited;
+        bool Uninherited;
         std::int32_t Effects;
+
+		bool operator< (const TimingPoint& other) const { return Time < other.Time; }
+		bool operator> (const TimingPoint& other) const { return Time > other.Time; }
+		bool operator== (const TimingPoint& other) const { return Time == other.Time; }
+		bool operator!= (const TimingPoint& other) const { return Time != other.Time; }
+		bool operator<= (const TimingPoint& other) const { return Time <= other.Time; }
+		bool operator>= (const TimingPoint& other) const { return Time >= other.Time; }
     };
 }

--- a/include/osu!parser/Parser/Utilities.hpp
+++ b/include/osu!parser/Parser/Utilities.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include <vector>
+#include <sstream>
 
 namespace Parser::Utilities
 {

--- a/include/osu!parser/Parser/Utilities.hpp
+++ b/include/osu!parser/Parser/Utilities.hpp
@@ -4,15 +4,31 @@
 
 namespace Parser::Utilities
 {
-    inline std::vector<std::string> Split(const std::string &Input, char Delimeter) 
+    inline std::vector<std::string> Split(const std::string &Input, char Delimeter, bool onlyTwoPart = false) 
     {
         std::vector<std::string> Output;
         std::stringstream Stream(Input);
-        std::string CurrentLine = "";
+        std::string CurrentLine;
 
-        while (std::getline(Stream, CurrentLine, Delimeter))
+        /**
+		 *  Why onlyTwoPart?
+		 *
+		 *  Because beatmap name can be "Operation: Zenithfall" - https://osu.ppy.sh/beatmapsets/2287992#osu/4881796
+		 *  (includes ':' in name).
+         */
+        if (onlyTwoPart)
         {
-            Output.push_back(CurrentLine);
+			std::getline(Stream, CurrentLine, Delimeter);
+			Output.push_back(CurrentLine);
+			std::getline(Stream, CurrentLine);
+			Output.push_back(CurrentLine);
+        }
+        else
+        {
+			while (std::getline(Stream, CurrentLine, Delimeter))
+			{
+				Output.push_back(CurrentLine);
+			}
         }
 
         return Output;


### PR DESCRIPTION
From [this beatmap](https://osu.ppy.sh/beatmapsets/2287992#osu/4881796), I discovered these problems:

## Fix:
### Beatmap:
- [x] - The name is missing (after `:`) - (`Operation: Zenithfall` -> `Operation`)
- [x] - Lost OD Value
- [x] - No [`hitSample`](https://osu.ppy.sh/wiki/en/Client/File_formats/osu_%28file_format%29#hit-objects) data
- [x] - Incorrect `Hitsound` parsing
- [x] - Incorrect `Type` parsing
- [x] - Missing value (`"N/A"`) may be misunderstand

so I managed to fix it :3

## Feature:
- [x] - Slider EndTime
- [x] - Split TimingPoints to UninheritedTimingPoints and InheritedTimingPoints
